### PR TITLE
Add sidebar navigation with profile

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { google } from "googleapis";
+import { cookies } from "next/headers";
+
+async function getGmail() {
+  const refreshToken = (await cookies()).get("refresh_token")?.value;
+  if (!refreshToken) {
+    throw new Error("Not authenticated");
+  }
+  const client = new google.auth.OAuth2(
+    process.env.GOOGLE_CLIENT_ID,
+    process.env.GOOGLE_CLIENT_SECRET,
+    process.env.GOOGLE_REDIRECT_URI
+  );
+  client.setCredentials({ refresh_token: refreshToken });
+  return google.gmail({ version: "v1", auth: client });
+}
+
+export async function GET() {
+  try {
+    const gmail = await getGmail();
+    const profile = await gmail.users.getProfile({ userId: "me" });
+    return NextResponse.json({ email: profile.data.emailAddress });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 401 });
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Sidebar from "@/components/Sidebar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <div className="flex min-h-screen">
+          <Sidebar />
+          <div className="flex-1 p-4">{children}</div>
+        </div>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,10 +9,6 @@ export default function HomePage() {
   const [results, setResults] = useState<{ category: string; summary: string }[]>([]);
   const [loading, setLoading] = useState(false);
 
-  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
-  const [calPrompt, setCalPrompt] = useState("아래 일정들을 요약해줘:");
-  const [calSummary, setCalSummary] = useState("");
-  const [calLoading, setCalLoading] = useState(false);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -51,24 +47,6 @@ export default function HomePage() {
     }
   };
 
-  const handleCalendarSummarize = async () => {
-    setCalLoading(true);
-    try {
-      const res = await axios.post("/api/calendar/summarize", {
-        date,
-        prompt: calPrompt,
-      });
-      setCalSummary(res.data.summary.parts?.[0].text);
-    } catch (err: any) {
-      if (axios.isAxiosError(err) && err.response?.status === 401) {
-        window.location.href = "/login";
-        return;
-      }
-      console.error(err);
-    } finally {
-      setCalLoading(false);
-    }
-  };
 
   return (
     <main className="p-6 max-w-xl mx-auto space-y-8">
@@ -106,32 +84,6 @@ export default function HomePage() {
             </li>
           ))}
         </ul>
-      </section>
-      <section>
-        <h1 className="text-2xl font-bold mb-4">Calendar Summarizer</h1>
-        <input
-          type="date"
-          value={date}
-          onChange={(e) => setDate(e.target.value)}
-          className="border p-2 w-full mb-4"
-        />
-        <textarea
-          className="border p-2 w-full mb-4"
-          value={calPrompt}
-          onChange={(e) => setCalPrompt(e.target.value)}
-          placeholder="Summary prompt"
-          rows={3}
-        />
-        <button
-          onClick={handleCalendarSummarize}
-          disabled={calLoading}
-          className="bg-blue-600 text-white px-4 py-2 rounded mb-6"
-        >
-          {calLoading ? "Summarizing..." : "Summarize Events"}
-        </button>
-        {calSummary && (
-          <p className="border p-4 rounded whitespace-pre-wrap">{calSummary}</p>
-        )}
       </section>
     </main>
   );

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,38 @@
+"use client";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import axios from "axios";
+
+export default function Sidebar() {
+  const [email, setEmail] = useState("");
+
+  useEffect(() => {
+    axios
+      .get("/api/profile")
+      .then((res) => setEmail(res.data.email))
+      .catch((err) => {
+        console.error(err);
+      });
+  }, []);
+
+  return (
+    <div className="w-64 bg-gray-100 p-4 space-y-4 min-h-screen">
+      <div>
+        <p className="font-bold mb-1">Profile</p>
+        {email ? (
+          <p className="text-sm break-all">{email}</p>
+        ) : (
+          <p className="text-sm text-gray-500">Not logged in</p>
+        )}
+      </div>
+      <nav className="space-y-2">
+        <Link href="/" className="block p-2 rounded hover:bg-gray-200">
+          Gmail Summary
+        </Link>
+        <Link href="/calendar" className="block p-2 rounded hover:bg-gray-200">
+          Calendar Summary
+        </Link>
+      </nav>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a profile API endpoint
- implement sidebar component with profile and links
- use the sidebar in the app layout
- simplify the home page to Gmail summary only

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68655dd9ac00832a92e6a92db9dc7c77