### PR TITLE
Integrate shadcn style components

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { useEffect, useState } from "react";
 import axios from "axios";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function CalendarPage() {
   const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
@@ -43,32 +45,32 @@ export default function CalendarPage() {
 
   return (
     <main className="p-6 max-w-xl mx-auto space-y-8">
-      <section>
-        <h1 className="text-2xl font-bold mb-4">Calendar Summarizer</h1>
-        <input
-          type="date"
-          value={date}
-          onChange={(e) => setDate(e.target.value)}
-          className="border p-2 w-full mb-4"
-        />
-        <textarea
-          className="border p-2 w-full mb-4"
-          value={calPrompt}
-          onChange={(e) => setCalPrompt(e.target.value)}
-          placeholder="Summary prompt"
-          rows={3}
-        />
-        <button
-          onClick={handleCalendarSummarize}
-          disabled={calLoading}
-          className="bg-blue-600 text-white px-4 py-2 rounded mb-6"
-        >
-          {calLoading ? "Summarizing..." : "Summarize Events"}
-        </button>
-        {calSummary && (
-          <p className="border p-4 rounded whitespace-pre-wrap">{calSummary}</p>
-        )}
-      </section>
+      <Card>
+        <CardHeader>
+          <CardTitle>Calendar Summarizer</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="border rounded-md p-2 w-full"
+          />
+          <textarea
+            className="border rounded-md p-2 w-full"
+            value={calPrompt}
+            onChange={(e) => setCalPrompt(e.target.value)}
+            placeholder="Summary prompt"
+            rows={3}
+          />
+          <Button onClick={handleCalendarSummarize} disabled={calLoading}>
+            {calLoading ? "Summarizing..." : "Summarize Events"}
+          </Button>
+          {calSummary && (
+            <p className="border p-4 rounded whitespace-pre-wrap">{calSummary}</p>
+          )}
+        </CardContent>
+      </Card>
     </main>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,11 +3,25 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --primary: #2563eb;
+  --primary-foreground: #ffffff;
+  --card: #ffffff;
+  --card-foreground: #171717;
+  --secondary: #f2f2f2;
+  --secondary-foreground: #171717;
+  --radius: 0.5rem;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --radius: var(--radius);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
@@ -16,11 +30,17 @@
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --primary: #3b82f6;
+    --primary-foreground: #ffffff;
+    --card: #171717;
+    --card-foreground: #ededed;
+    --secondary: #27272a;
+    --secondary-foreground: #ededed;
   }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { useEffect, useState } from "react";
 import axios from "axios";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function HomePage() {
   const query = "is:unread";
@@ -54,10 +56,13 @@ export default function HomePage() {
 
   return (
     <main className="p-6 max-w-xl mx-auto space-y-8">
-      <section>
-        <h1 className="text-2xl font-bold mb-4">Gmail Email Summarizer</h1>
-        <select
-          className="border p-2 w-full mb-4"
+      <Card>
+        <CardHeader>
+          <CardTitle>Gmail Email Summarizer</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <select
+            className="border rounded-md p-2 w-full"
           value={days}
           onChange={(e) => setDays(e.target.value)}
         >
@@ -66,8 +71,8 @@ export default function HomePage() {
           <option value="7">최근 1주</option>
           <option value="30">최근 1달</option>
         </select>
-        <select
-          className="border p-2 w-full mb-4"
+          <select
+            className="border rounded-md p-2 w-full"
           value={count}
           onChange={(e) => setCount(e.target.value)}
         >
@@ -75,7 +80,7 @@ export default function HomePage() {
           <option value="10">이메일 10개</option>
           <option value="15">이메일 15개</option>
         </select>
-        <label className="flex items-center mb-4 space-x-2">
+          <label className="flex items-center space-x-2">
           <input
             type="checkbox"
             checked={markRead}
@@ -83,29 +88,30 @@ export default function HomePage() {
           />
           <span>읽음 처리</span>
         </label>
-        <textarea
-          className="border p-2 w-full mb-4"
+          <textarea
+            className="border rounded-md p-2 w-full"
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           placeholder="Summary prompt"
           rows={3}
         />
-        <button
-          onClick={handleSummarize}
-          disabled={loading}
-          className="bg-blue-600 text-white px-4 py-2 rounded mb-6"
-        >
-          {loading ? "Summarizing..." : "Summarize Emails"}
-        </button>
-        <ul className="space-y-4">
+          <Button onClick={handleSummarize} disabled={loading}>
+            {loading ? "Summarizing..." : "Summarize Emails"}
+          </Button>
+        </CardContent>
+      </Card>
+      <ul className="space-y-4">
           {results.map((r) => (
-            <li key={r.category} className="border p-4 rounded">
-              <p className="font-medium">{r.category}</p>
-              <p>{r.summary}</p>
-            </li>
+            <Card key={r.category}>
+              <CardHeader>
+                <CardTitle className="text-lg">{r.category}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p>{r.summary}</p>
+              </CardContent>
+            </Card>
           ))}
-        </ul>
-      </section>
+      </ul>
     </main>
   );
 }

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -2,6 +2,8 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import axios from "axios";
+import { Card, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 
 export default function Sidebar() {
   const [email, setEmail] = useState("");
@@ -16,23 +18,27 @@ export default function Sidebar() {
   }, []);
 
   return (
-    <div className="w-64 bg-gray-100 p-4 space-y-4 min-h-screen">
-      <div>
+    <Card className="w-64 min-h-screen rounded-none border-r">
+      <CardHeader>
         <p className="font-bold mb-1">Profile</p>
         {email ? (
           <p className="text-sm break-all">{email}</p>
         ) : (
-          <p className="text-sm text-gray-500">Not logged in</p>
+          <p className="text-sm text-muted-foreground">Not logged in</p>
         )}
-      </div>
-      <nav className="space-y-2">
-        <Link href="/" className="block p-2 rounded hover:bg-gray-200">
-          Gmail Summary
+      </CardHeader>
+      <nav className="space-y-2 px-6 pb-6">
+        <Link href="/">
+          <Button variant="outline" className="w-full justify-start">
+            Gmail Summary
+          </Button>
         </Link>
-        <Link href="/calendar" className="block p-2 rounded hover:bg-gray-200">
-          Calendar Summary
+        <Link href="/calendar">
+          <Button variant="outline" className="w-full justify-start">
+            Calendar Summary
+          </Button>
         </Link>
       </nav>
-    </div>
+    </Card>
   );
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,21 @@
+import { ButtonHTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+type Variant = "default" | "outline" | "secondary";
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+}
+
+const base =
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50";
+
+const variants: Record<Variant, string> = {
+  default: "bg-primary text-primary-foreground hover:bg-primary/90",
+  outline:
+    "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+  secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+};
+
+export function Button({ variant = "default", className, ...props }: ButtonProps) {
+  return <button className={cn(base, variants[variant], className)} {...props} />;
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,27 @@
+import { HTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export function CardHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />;
+}
+
+export function CardTitle({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn("text-2xl font-semibold leading-none tracking-tight", className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("p-6 pt-0", className)} {...props} />;
+}
+
+export function CardFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex items-center p-6 pt-0", className)} {...props} />;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | null | false)[]) {
+  return classes.filter(Boolean).join(" ");
+}


### PR DESCRIPTION
## Summary
- create shadcn-style `Button` and `Card` components
- apply new components across pages and sidebar
- define CSS variables for primary/card colors
- add simple `cn` helper

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867262cff30832a9e17410f2267c681