### PR TITLE
Add MDX rendering support

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import axios from "axios";
+import MdxView from "@/components/MdxView";
 
 export default function CalendarPage() {
   const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
@@ -66,7 +67,9 @@ export default function CalendarPage() {
           {calLoading ? "Summarizing..." : "Summarize Events"}
         </button>
         {calSummary && (
-          <p className="border p-4 rounded whitespace-pre-wrap">{calSummary}</p>
+          <div className="border p-4 rounded">
+            <MdxView content={calSummary} />
+          </div>
         )}
       </section>
     </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import axios from "axios";
+import MdxView from "@/components/MdxView";
 
 export default function HomePage() {
   const query = "is:unread";
@@ -99,9 +100,9 @@ export default function HomePage() {
         </button>
         <ul className="space-y-4">
           {results.map((r) => (
-            <li key={r.category} className="border p-4 rounded">
+            <li key={r.category} className="border p-4 rounded space-y-2">
               <p className="font-medium">{r.category}</p>
-              <p>{r.summary}</p>
+              <MdxView content={r.summary} />
             </li>
           ))}
         </ul>

--- a/components/MdxView.tsx
+++ b/components/MdxView.tsx
@@ -1,0 +1,103 @@
+"use client";
+import React from "react";
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function parseInline(text: string): string {
+  return escapeHtml(text)
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>")
+    .replace(/`([^`]+)`/g, "<code>$1</code>");
+}
+
+export function mdxToHtml(mdx: string): string {
+  const lines = mdx.split(/\r?\n/);
+  let html = "";
+  let list: "ul" | "ol" | null = null;
+  let inCode = false;
+  let codeBuffer: string[] = [];
+
+  const closeList = () => {
+    if (list) {
+      html += `</${list}>`;
+      list = null;
+    }
+  };
+
+  const flushCode = () => {
+    if (inCode) {
+      html += `<pre><code>${escapeHtml(codeBuffer.join("\n"))}</code></pre>`;
+      inCode = false;
+      codeBuffer = [];
+    }
+  };
+
+  for (const line of lines) {
+    if (line.startsWith("```")) {
+      if (inCode) {
+        flushCode();
+      } else {
+        inCode = true;
+      }
+      continue;
+    }
+
+    if (inCode) {
+      codeBuffer.push(line);
+      continue;
+    }
+
+    const heading = line.match(/^(#{1,3})\s+(.*)/);
+    if (heading) {
+      closeList();
+      const level = heading[1].length;
+      html += `<h${level}>${parseInline(heading[2])}</h${level}>`;
+      continue;
+    }
+
+    const ol = line.match(/^\d+\.\s+(.*)/);
+    if (ol) {
+      if (list !== "ol") {
+        closeList();
+        list = "ol";
+        html += `<ol>`;
+      }
+      html += `<li>${parseInline(ol[1])}</li>`;
+      continue;
+    }
+
+    const ul = line.match(/^[-*+]\s+(.*)/);
+    if (ul) {
+      if (list !== "ul") {
+        closeList();
+        list = "ul";
+        html += `<ul>`;
+      }
+      html += `<li>${parseInline(ul[1])}</li>`;
+      continue;
+    }
+
+    if (line.trim() === "") {
+      closeList();
+      html += "<br/>";
+      continue;
+    }
+
+    closeList();
+    html += `<p>${parseInline(line)}</p>`;
+  }
+
+  flushCode();
+  closeList();
+  return html;
+}
+
+export default function MdxView({ content }: { content: string }) {
+  return <div dangerouslySetInnerHTML={{ __html: mdxToHtml(content) }} />;
+}
+


### PR DESCRIPTION
## Summary
- render MDX strings from the API results
- implement simple MDX parser component

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672ec83de8832a80a8e3aac4f8cdd4