### PR TITLE
Add saved prompts per account

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -8,6 +8,7 @@ export default function CalendarPage() {
   const [calPrompt, setCalPrompt] = useState("아래 일정들을 요약해줘:");
   const [calSummary, setCalSummary] = useState("");
   const [calLoading, setCalLoading] = useState(false);
+  const [email, setEmail] = useState("");
 
 
   useEffect(() => {
@@ -20,6 +21,27 @@ export default function CalendarPage() {
       finish();
     }
   }, []);
+
+  useEffect(() => {
+    axios
+      .get("/api/profile")
+      .then((res) => {
+        if (res.data.email) {
+          setEmail(res.data.email);
+          const saved = localStorage.getItem(
+            `calendar_prompt_${res.data.email}`
+          );
+          if (saved) setCalPrompt(saved);
+        }
+      })
+      .catch((err) => console.error(err));
+  }, []);
+
+  useEffect(() => {
+    if (email) {
+      localStorage.setItem(`calendar_prompt_${email}`, calPrompt);
+    }
+  }, [email, calPrompt]);
 
   const handleCalendarSummarize = async () => {
     setCalLoading(true);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ export default function HomePage() {
   const [prompt, setPrompt] = useState("이메일 내용을 요약해줘:");
   const [results, setResults] = useState<{ category: string; summary: string }[]>([]);
   const [loading, setLoading] = useState(false);
+  const [email, setEmail] = useState("");
 
 
   useEffect(() => {
@@ -23,6 +24,25 @@ export default function HomePage() {
       finish();
     }
   }, []);
+
+  useEffect(() => {
+    axios
+      .get("/api/profile")
+      .then((res) => {
+        if (res.data.email) {
+          setEmail(res.data.email);
+          const saved = localStorage.getItem(`gmail_prompt_${res.data.email}`);
+          if (saved) setPrompt(saved);
+        }
+      })
+      .catch((err) => console.error(err));
+  }, []);
+
+  useEffect(() => {
+    if (email) {
+      localStorage.setItem(`gmail_prompt_${email}`, prompt);
+    }
+  }, [email, prompt]);
 
   const handleSummarize = async () => {
     setLoading(true);


### PR DESCRIPTION
## Summary
- store the gmail prompt per user
- store the calendar prompt per user

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686732cc1140832a8a786cb2db7dce8b