### PR TITLE
Enhance email group display

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import MdxView from "@/components/MdxView";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
 import {
   Select,
   SelectContent,
@@ -39,7 +40,13 @@ export default function HomePage() {
   const [count, setCount] = useState("15");
   const [markRead, setMarkRead] = useState(true);
   const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
-  const [results, setResults] = useState<{ category: string; summary: string }[]>([]);
+  const [results, setResults] = useState<
+    { category: string; label: string; summary: string }[]
+  >([]);
+  const CATEGORY_LABELS: Record<string, string> = {
+    internal: "사내 메일",
+    external: "사외 메일",
+  };
   const [loading, setLoading] = useState(false);
   const [email, setEmail] = useState("");
 
@@ -88,6 +95,7 @@ export default function HomePage() {
       setResults(
         res.data.groupSummaries.map((item: any) => ({
           category: item.category,
+          label: CATEGORY_LABELS[item.category] || item.category,
           summary: item.summary.parts?.[0].text,
         }))
       );
@@ -171,8 +179,8 @@ export default function HomePage() {
         <ul className="space-y-4">
           {results.map((r) => (
             <li key={r.category} className="border p-4 rounded space-y-2">
-              <p className="font-medium">{r.category}</p>
-              <MdxView content={r.summary}/>
+              <Badge variant={r.category as any}>{r.label}</Badge>
+              <MdxView content={r.summary} />
             </li>
           ))}
         </ul>

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,43 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-muted text-muted-foreground",
+        github:
+          "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+        jira:
+          "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+        internal:
+          "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+        external:
+          "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+type BadgeProps = React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants>
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <span
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }
+


### PR DESCRIPTION
## Summary
- add Badge component
- show group labels with badges
- map internal and external groups to Korean labels for clarity

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686743320420832a959a006d28cd3c89