### PR TITLE
Add Slack message summarizer

### DIFF
--- a/app/api/slack/summarize/route.ts
+++ b/app/api/slack/summarize/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { summarizeWithGemini } from "@/lib/gemini";
+
+async function fetchUnreadMessages(count: number): Promise<string[]> {
+  const token = process.env.SLACK_BOT_TOKEN;
+  if (!token) {
+    throw new Error("Slack token not configured");
+  }
+  const res = await fetch(
+    `https://slack.com/api/search.messages?query=is:unread&count=${count}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  const data = await res.json();
+  if (!data.ok) {
+    throw new Error(data.error || "Failed to fetch Slack messages");
+  }
+  const matches = data.messages?.matches || [];
+  return matches.map((m: any) => m.text as string);
+}
+
+export async function POST(request: Request) {
+  const { count = 20, prompt } = await request.json();
+  try {
+    const messages = await fetchUnreadMessages(Number(count));
+    const text = messages.join("\n");
+    const summaryPrompt = prompt || "아래 슬랙 메시지들을 요약해줘:";
+    const summary = await summarizeWithGemini(text, summaryPrompt);
+    return NextResponse.json({ summary });
+  } catch (error: any) {
+    console.error("Slack summarization error", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/app/slack/page.tsx
+++ b/app/slack/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { useState } from "react";
+import axios from "axios";
+import MdxView from "@/components/MdxView";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+const DEFAULT_PROMPT = `아래 슬랙 메시지들을 요약해줘:
+- 중요하거나 긴급한 내용 위주로 정리해줘.
+- 비슷한 주제는 묶어서 보여줘.`;
+
+export default function SlackPage() {
+  const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
+  const [loading, setLoading] = useState(false);
+  const [summary, setSummary] = useState("");
+
+  const handleSummarize = async () => {
+    setLoading(true);
+    try {
+      const res = await axios.post("/api/slack/summarize", { prompt });
+      setSummary(res.data.summary.parts?.[0].text ?? "");
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="p-6 max-w-xl mx-auto space-y-8">
+      <section>
+        <h1 className="text-2xl font-bold mb-4">Slack Message Summarizer</h1>
+        <Textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          rows={3}
+          className="mb-4"
+        />
+        <Button onClick={handleSummarize} disabled={loading} className="mb-6">
+          {loading ? "Summarizing..." : "Summarize Messages"}
+        </Button>
+        {summary && (
+          <div className="border p-4 rounded">
+            <MdxView content={summary} />
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -46,7 +46,12 @@ export default function Sidebar() {
                   </SidebarMenuButton>
                 </SidebarMenuItem>
                 <SidebarMenuItem>
-                  <SidebarMenuButton asChild isActive={typeof window !== 'undefined' && window.location.pathname.startsWith("/calendar")}> 
+                  <SidebarMenuButton asChild isActive={typeof window !== 'undefined' && window.location.pathname.startsWith("/slack")}>
+                    <Link href="/slack">Slack 요약</Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild isActive={typeof window !== 'undefined' && window.location.pathname.startsWith("/calendar")}>
                     <Link href="/calendar">일정 요약</Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>


### PR DESCRIPTION
## Summary
- integrate Slack API with Gemini summarizer
- show Slack summary page
- link Slack page in sidebar navigation

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674ee37bd8832a82ec1d46182e729c