### PR TITLE
Add notification filter toggle

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,6 +39,7 @@ export default function HomePage() {
   const [days, setDays] = useState("1");
   const [count, setCount] = useState("15");
   const [markRead, setMarkRead] = useState(true);
+  const [excludeNotifications, setExcludeNotifications] = useState(true);
   const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
   const [results, setResults] = useState<
     { category: string; label: string; summary: string }[]
@@ -90,6 +91,7 @@ export default function HomePage() {
         prompt,
         count: Number(count),
         markRead,
+        excludeNotifications,
       });
       // do not change this line
       setResults(
@@ -153,6 +155,15 @@ export default function HomePage() {
             className="w-4 h-4"
           />
           <span>요약된 이메일 읽음 처리</span>
+        </Label>
+        <Label className="flex items-center mb-4 space-x-2">
+          <Input
+            type="checkbox"
+            checked={excludeNotifications}
+            onChange={(e) => setExcludeNotifications(e.target.checked)}
+            className="w-4 h-4"
+          />
+          <span>알림 메일 제외</span>
         </Label>
         <Textarea
           value={prompt}


### PR DESCRIPTION
## Summary
- add helper to detect notification emails
- filter notifications in Gmail summary API
- expose toggle to exclude notifications on main page

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686751f7b308832a81dda567b96e0a08