### PR TITLE
Add docs-to-jira page

### DIFF
--- a/app/api/auth/url/route.ts
+++ b/app/api/auth/url/route.ts
@@ -14,6 +14,7 @@ export async function GET() {
       "https://www.googleapis.com/auth/gmail.readonly",
       "https://www.googleapis.com/auth/gmail.modify",
       "https://www.googleapis.com/auth/calendar.readonly",
+      "https://www.googleapis.com/auth/documents.readonly",
     ],
     prompt: "consent",
   });

--- a/app/api/jira/create/route.ts
+++ b/app/api/jira/create/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { google } from "googleapis";
+import { summarizeWithGemini } from "@/lib/gemini";
+
+function extractDocId(url: string): string | null {
+  const m = url.match(/\/d\/(.+?)(?:\/|$)/);
+  return m ? m[1] : null;
+}
+
+async function getDocs() {
+  const refreshToken = (await cookies()).get("refresh_token")?.value;
+  if (!refreshToken) {
+    throw new Error("Not authenticated");
+  }
+  const client = new google.auth.OAuth2(
+    process.env.GOOGLE_CLIENT_ID,
+    process.env.GOOGLE_CLIENT_SECRET,
+    process.env.GOOGLE_REDIRECT_URI
+  );
+  client.setCredentials({ refresh_token: refreshToken });
+  return google.docs({ version: "v1", auth: client });
+}
+
+function extractText(elements: any[]): string {
+  let text = "";
+  for (const el of elements) {
+    if (el.paragraph) {
+      for (const pe of el.paragraph.elements || []) {
+        text += pe.textRun?.content || "";
+      }
+      text += "\n";
+    }
+  }
+  return text;
+}
+
+async function fetchDocumentText(docId: string): Promise<string> {
+  const docs = await getDocs();
+  const res = await docs.documents.get({ documentId: docId });
+  return extractText(res.data.body?.content || []);
+}
+
+function parseJson(text: string): { title: string; description: string } | null {
+  try {
+    // remove code block markers if present
+    const cleaned = text.replace(/^```(?:json)?|```$/g, "");
+    return JSON.parse(cleaned);
+  } catch {
+    return null;
+  }
+}
+
+async function createJiraIssue(title: string, description: string) {
+  if (
+    !process.env.JIRA_BASE_URL ||
+    !process.env.JIRA_EMAIL ||
+    !process.env.JIRA_TOKEN ||
+    !process.env.JIRA_PROJECT_KEY
+  ) {
+    throw new Error("Jira environment variables not configured");
+  }
+  const auth = Buffer.from(
+    `${process.env.JIRA_EMAIL}:${process.env.JIRA_TOKEN}`
+  ).toString("base64");
+  const res = await fetch(`${process.env.JIRA_BASE_URL}/rest/api/3/issue`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${auth}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      fields: {
+        project: { key: process.env.JIRA_PROJECT_KEY },
+        summary: title,
+        description,
+        issuetype: { name: "Task" },
+      },
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text);
+  }
+  const data = await res.json();
+  return data.key as string;
+}
+
+export async function POST(request: Request) {
+  const { url } = await request.json();
+  if (!url) {
+    return NextResponse.json({ error: "Missing url" }, { status: 400 });
+  }
+  try {
+    const docId = extractDocId(url);
+    if (!docId) {
+      return NextResponse.json({ error: "Invalid Google Docs url" }, { status: 400 });
+    }
+    const text = await fetchDocumentText(docId);
+    const prompt =
+      "다음 문서를 읽고 JIRA 티켓 생성을 위한 title과 description을 한국어 JSON으로 제공해줘. 형식: {\"title\":\"...\",\"description\":\"...\"}";
+    const summary = await summarizeWithGemini(text, prompt);
+    const parsed = parseJson(summary as any) || { title: "Auto Generated", description: summary as any };
+    const key = await createJiraIssue(parsed.title, parsed.description);
+    return NextResponse.json({ key });
+  } catch (error: any) {
+    if (error.message === "Not authenticated") {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/app/jira/page.tsx
+++ b/app/jira/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { useState } from "react";
+import axios from "axios";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+export default function JiraPage() {
+  const [url, setUrl] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
+
+  const handleCreate = async () => {
+    setLoading(true);
+    setMessage("");
+    try {
+      const res = await axios.post("/api/jira/create", { url });
+      setMessage(`Created issue ${res.data.key}`);
+    } catch (err: any) {
+      const msg = err.response?.data?.error || err.message;
+      setMessage(`Error: ${msg}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="p-6 max-w-xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold mb-4">Google Docs to JIRA</h1>
+      <Input
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        placeholder="Google Docs link"
+        className="mb-4"
+      />
+      <Button onClick={handleCreate} disabled={loading || !url}>
+        {loading ? "Creating..." : "Create JIRA Ticket"}
+      </Button>
+      {message && <p className="mt-4 break-all">{message}</p>}
+    </main>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -56,6 +56,11 @@ export default function Sidebar() {
                   </SidebarMenuButton>
                 </SidebarMenuItem>
                 <SidebarMenuItem>
+                  <SidebarMenuButton asChild isActive={typeof window !== 'undefined' && window.location.pathname.startsWith("/jira")}>
+                    <Link href="/jira">Doc → Jira</Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
                   <SidebarMenuButton asChild isActive={typeof window !== 'undefined' && window.location.pathname.startsWith("/TBU")}>
                     <Link href="/TBU">TBU (더 많은 AI 기능들..!)</Link>
                   </SidebarMenuButton>


### PR DESCRIPTION
## Summary
- support Google Docs scope for auth
- add a Docs→Jira page
- create Jira issue from Docs via new API
- link Jira page in sidebar

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68675d835590832a866f813e44f05536