### PR TITLE
Enable custom prompt for Jira tickets

### DIFF
--- a/app/jira/page.tsx
+++ b/app/jira/page.tsx
@@ -3,9 +3,14 @@ import { useState } from "react";
 import axios from "axios";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+const DEFAULT_PROMPT =
+  "다음 문서를 읽고 JIRA 티켓 생성을 위한 title과 description을 한국어 JSON으로 제공해줘. 형식: {\"title\":\"...\",\"description\":\"...\"}";
 
 export default function JiraPage() {
   const [url, setUrl] = useState("");
+  const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
 
@@ -13,7 +18,7 @@ export default function JiraPage() {
     setLoading(true);
     setMessage("");
     try {
-      const res = await axios.post("/api/jira/create", { url });
+      const res = await axios.post("/api/jira/create", { url, prompt });
       setMessage(`Created issue ${res.data.key}`);
     } catch (err: any) {
       const msg = err.response?.data?.error || err.message;
@@ -30,6 +35,12 @@ export default function JiraPage() {
         value={url}
         onChange={(e) => setUrl(e.target.value)}
         placeholder="Google Docs link"
+        className="mb-4"
+      />
+      <Textarea
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        rows={3}
         className="mb-4"
       />
       <Button onClick={handleCreate} disabled={loading || !url}>


### PR DESCRIPTION
## Summary
- support a `prompt` field on the Jira create API
- expose a textarea on the Jira page for the custom prompt

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686768a183cc832ab50d1d604aedc204